### PR TITLE
Revert "Fixing accordingly to new foundry property"

### DIFF
--- a/scripts/scene-viewer.js
+++ b/scripts/scene-viewer.js
@@ -40,7 +40,7 @@ function log(...args) {
 
 function loadImage(scene){
     log("Loading Scene:", scene)
-    const image = scene.img;
+    const image = scene.background.src;
     if(!image){
         ui.notifications.warn(game.i18n.localize("SCENE_VIEWER.NoImage"))
         return


### PR DESCRIPTION
Wait, no... What you did just reverted to the v9 property.  Looks like there's a core bug which is making things not display properly.  Should be able to get this fixed tomorrow when I have more time to poke at it.