### PR TITLE
Ensure that images are fully shown

### DIFF
--- a/templates/media-popout.html
+++ b/templates/media-popout.html
@@ -2,6 +2,6 @@
 	{{#if isVideo}}
 		<video autoplay loop muted playsinline src="{{image}}">
 	{{else}}
-		<div class="lightbox-image" style="background-image: url('{{image}}')" title="{{title}}"></div>
+		<div class="lightbox-image" style="background-size: contain; background-image: url('{{image}}')" title="{{title}}"></div>
 	{{/if}}
 </form>


### PR DESCRIPTION
The CSS style “background-size: contain” ensures that the image of the scene is shown fully in the preview window. In some browsers, images are only show partially and scrolling is not possible.